### PR TITLE
Report ExitFailures from cluster worker exits

### DIFF
--- a/src/Internal/ContextClusterWorker.php
+++ b/src/Internal/ContextClusterWorker.php
@@ -109,7 +109,13 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
                 };
             }
 
-            $this->joinFuture->await(new TimeoutCancellation(ClusterWatcher::WORKER_TIMEOUT));
+            try {
+                $this->joinFuture->await(new TimeoutCancellation(ClusterWatcher::WORKER_TIMEOUT));
+            } catch (CancelledException) {
+                $this->close();
+                // Give it a second to reap the result. Generally this never should time out, unless something is seriously broken.
+                $this->joinFuture->await(new TimeoutCancellation(1));
+            }
         } catch (\Throwable $exception) {
             $this->joinFuture->ignore();
             throw $exception;


### PR DESCRIPTION
This relies on amphp/parallel#207.

This prevents `Worker {$id} forcefully terminated as part of watcher shutdown` (if the process did not shutdown properly and has to be killed) or simply `Worker 7 died unexpectedly: Context exited with code 137, restarting...`, providing information about the actual failure.