### PR TITLE
Allow configuring the cluster worker ping timeout

### DIFF
--- a/src/ClusterWatcher.php
+++ b/src/ClusterWatcher.php
@@ -65,6 +65,11 @@ final class ClusterWatcher
     /**
      * @param string|array<string> $script Script path and optional arguments.
      * @param IpcHub $hub Sockets returned from {@see IpcHub::accept()} must be an instance of {@see ResourceSocket}.
+     * @param positive-int $workerPingTimeout Seconds without activity before
+     *     the watcher considers a worker dead and terminates it. Default
+     *     {@see Internal\ContextClusterWorker::DEFAULT_PING_TIMEOUT}. Increase
+     *     for applications that legitimately do synchronous blocking work
+     *     (e.g. PDO drivers) longer than the default ceiling.
      */
     public function __construct(
         string|array $script,
@@ -72,9 +77,16 @@ final class ClusterWatcher
         private readonly IpcHub $hub = new LocalIpcHub(),
         ?ContextFactory $contextFactory = null,
         private readonly ServerSocketPipeProvider $provider = new ServerSocketPipeProvider(),
+        private readonly int $workerPingTimeout = ContextClusterWorker::DEFAULT_PING_TIMEOUT,
     ) {
         if (Cluster::isWorker()) {
             throw new \Error("A new cluster cannot be created from within a cluster worker");
+        }
+
+        if ($workerPingTimeout < 1) {
+            throw new \ValueError(
+                'Worker ping timeout must be a positive integer (seconds); got ' . $workerPingTimeout,
+            );
         }
 
         $this->script = \array_merge(
@@ -187,6 +199,7 @@ final class ClusterWatcher
             $this->queue,
             $deferredCancellation,
             $this->logger,
+            $this->workerPingTimeout,
         );
 
         $worker->info(\sprintf('Started cluster worker with ID %d', $id));

--- a/src/ClusterWatcher.php
+++ b/src/ClusterWatcher.php
@@ -80,6 +80,11 @@ final class ClusterWatcher
     /**
      * @param string|array<string> $script Script path and optional arguments.
      * @param IpcHub $hub Sockets returned from {@see IpcHub::accept()} must be an instance of {@see ResourceSocket}.
+     * @param float|null $workerShutdownTimeout The maximum time to wait for a worker to shut down, in seconds,
+     *       or null to wait indefinitely.
+     * @param float $workerPingTimeout Seconds without activity before the watcher considers a worker dead
+     *       and terminates it. Default {@see self::DEFAULT_WORKER_PING_TIMEOUT}. Increase or applications that
+     *       legitimately do synchronous blocking work (e.g. PDO drivers) longer than the default ceiling.
      */
     public function __construct(
         string|array $script,
@@ -87,9 +92,25 @@ final class ClusterWatcher
         private readonly IpcHub $hub = new LocalIpcHub(),
         ?ContextFactory $contextFactory = null,
         private readonly ServerSocketPipeProvider $provider = new ServerSocketPipeProvider(),
+        private readonly ?float $workerShutdownTimeout = self::DEFAULT_WORKER_SHUTDOWN_TIMEOUT,
+        private readonly float $workerPingTimeout = self::DEFAULT_WORKER_PING_TIMEOUT,
     ) {
         if (Cluster::isWorker()) {
             throw new \Error("A new cluster cannot be created from within a cluster worker");
+        }
+
+        if ($this->workerShutdownTimeout !== null && $this->workerShutdownTimeout <= 0) {
+            throw new \ValueError(\sprintf(
+                'Worker shutdown timeout must be NULL or greater than zero (seconds); got %.3f',
+                $this->workerShutdownTimeout,
+            ));
+        }
+
+        if ($this->workerPingTimeout <= 0) {
+            throw new \ValueError(\sprintf(
+                'Worker ping timeout must be greater than zero (seconds); got %.3f',
+                $this->workerPingTimeout,
+            ));
         }
 
         $this->script = \array_merge(
@@ -135,17 +156,9 @@ final class ClusterWatcher
 
     /**
      * @param int $count Number of cluster workers to spawn.
-     * @param float|null $workerShutdownTimeout The maximum time to wait for a worker to shut down, in seconds,
-     *      or null to wait indefinitely.
-     * @param float $workerPingTimeout Seconds without activity before the watcher considers a worker dead
-     *      and terminates it. Default {@see self::DEFAULT_WORKER_PING_TIMEOUT}. Increase or applications that
-     *      legitimately do synchronous blocking work (e.g. PDO drivers) longer than the default ceiling.
      */
-    public function start(
-        int $count,
-        ?float $workerShutdownTimeout = self::DEFAULT_WORKER_SHUTDOWN_TIMEOUT,
-        float $workerPingTimeout = self::DEFAULT_WORKER_PING_TIMEOUT,
-    ): void {
+    public function start(int $count): void
+    {
         if ($this->running || $this->queue->isComplete()) {
             throw new \Error("The cluster watcher is already running or has already run");
         }
@@ -154,27 +167,13 @@ final class ClusterWatcher
             throw new \ValueError("The number of workers must be greater than zero");
         }
 
-        if ($workerShutdownTimeout !== null && $workerShutdownTimeout <= 0) {
-            throw new \ValueError(\sprintf(
-                'Worker shutdown timeout must be NULL or greater than zero (seconds); got %.3f',
-                $workerShutdownTimeout,
-            ));
-        }
-
-        if ($workerPingTimeout <= 0) {
-            throw new \ValueError(\sprintf(
-                'Worker ping timeout must be greater than zero (seconds); got %.3f',
-                $workerPingTimeout,
-            ));
-        }
-
         $this->workers = [];
         $this->running = true;
 
         try {
             for ($i = 0; $i < $count; ++$i) {
                 $id = $this->nextId++;
-                $this->workers[$id] = $this->startWorker($id, $workerShutdownTimeout, $workerPingTimeout);
+                $this->workers[$id] = $this->startWorker($id);
             }
         } catch (\Throwable $exception) {
             $this->stop();
@@ -184,10 +183,8 @@ final class ClusterWatcher
 
     /**
      * @param positive-int $id The worker ID.
-     * @param float|null $shutdownTimeout The maximum time to wait for the worker to shut down, in seconds,
-     *  or null to wait indefinitely.
      */
-    private function startWorker(int $id, ?float $shutdownTimeout, float $pingTimeout): ContextClusterWorker
+    private function startWorker(int $id): ContextClusterWorker
     {
         $context = $this->contextFactory->start($this->script);
 
@@ -242,14 +239,12 @@ final class ClusterWatcher
             $socket,
             $deferredCancellation,
             $id,
-            $shutdownTimeout,
-            $pingTimeout,
         ): void {
             async($this->provider->provideFor(...), $socket, $deferredCancellation->getCancellation())->ignore();
 
             try {
                 try {
-                    $worker->run($shutdownTimeout, $pingTimeout);
+                    $worker->run($this->workerPingTimeout, $this->workerShutdownTimeout);
 
                     $worker->info("Worker {$id} terminated cleanly" .
                         ($this->running ? ", restarting..." : ""));
@@ -274,7 +269,7 @@ final class ClusterWatcher
                     unset($this->workers[$id]);
 
                     $id = $this->nextId++;
-                    $this->workers[$id] = $this->startWorker($id, $shutdownTimeout, $pingTimeout);
+                    $this->workers[$id] = $this->startWorker($id);
                 }
             } catch (\Throwable $exception) {
                 $this->stop();

--- a/src/ClusterWatcher.php
+++ b/src/ClusterWatcher.php
@@ -154,16 +154,18 @@ final class ClusterWatcher
             throw new \ValueError("The number of workers must be greater than zero");
         }
 
-        if ($workerShutdownTimeout <= 0) {
-            throw new \ValueError(
-                'Worker shutdown timeout must be greater than zero (seconds); got ' . $workerShutdownTimeout,
-            );
+        if ($workerShutdownTimeout !== null && $workerShutdownTimeout <= 0) {
+            throw new \ValueError(\sprintf(
+                'Worker shutdown timeout must be NULL or greater than zero (seconds); got %.3f',
+                $workerShutdownTimeout,
+            ));
         }
 
         if ($workerPingTimeout <= 0) {
-            throw new \ValueError(
-                'Worker ping timeout must be greater than zero (seconds); got ' . $workerPingTimeout,
-            );
+            throw new \ValueError(\sprintf(
+                'Worker ping timeout must be greater than zero (seconds); got %.3f',
+                $workerPingTimeout,
+            ));
         }
 
         $this->workers = [];

--- a/src/ClusterWatcher.php
+++ b/src/ClusterWatcher.php
@@ -38,8 +38,20 @@ final class ClusterWatcher
 
     /**
      * The default worker shutdown timeout in seconds.
+     *
+     * @deprecated Use {@see self::DEFAULT_WORKER_SHUTDOWN_TIMEOUT} instead.
      */
-    public const WORKER_TIMEOUT = 5;
+    public const WORKER_TIMEOUT = self::DEFAULT_WORKER_SHUTDOWN_TIMEOUT;
+
+    /**
+     * The default worker shutdown timeout in seconds.
+     */
+    public const DEFAULT_WORKER_SHUTDOWN_TIMEOUT = 5;
+
+    /**
+     * The default worker ping timeout in seconds.
+     */
+    public const DEFAULT_WORKER_PING_TIMEOUT = 10;
 
     private readonly ContextFactory $contextFactory;
 
@@ -68,11 +80,6 @@ final class ClusterWatcher
     /**
      * @param string|array<string> $script Script path and optional arguments.
      * @param IpcHub $hub Sockets returned from {@see IpcHub::accept()} must be an instance of {@see ResourceSocket}.
-     * @param positive-int $workerPingTimeout Seconds without activity before
-     *     the watcher considers a worker dead and terminates it. Default
-     *     {@see Internal\ContextClusterWorker::DEFAULT_PING_TIMEOUT}. Increase
-     *     for applications that legitimately do synchronous blocking work
-     *     (e.g. PDO drivers) longer than the default ceiling.
      */
     public function __construct(
         string|array $script,
@@ -80,16 +87,9 @@ final class ClusterWatcher
         private readonly IpcHub $hub = new LocalIpcHub(),
         ?ContextFactory $contextFactory = null,
         private readonly ServerSocketPipeProvider $provider = new ServerSocketPipeProvider(),
-        private readonly int $workerPingTimeout = ContextClusterWorker::DEFAULT_PING_TIMEOUT,
     ) {
         if (Cluster::isWorker()) {
             throw new \Error("A new cluster cannot be created from within a cluster worker");
-        }
-
-        if ($workerPingTimeout < 1) {
-            throw new \ValueError(
-                'Worker ping timeout must be a positive integer (seconds); got ' . $workerPingTimeout,
-            );
         }
 
         $this->script = \array_merge(
@@ -136,16 +136,34 @@ final class ClusterWatcher
     /**
      * @param int $count Number of cluster workers to spawn.
      * @param float|null $workerShutdownTimeout The maximum time to wait for a worker to shut down, in seconds,
-     *  or null to wait indefinitely.
+     *      or null to wait indefinitely.
+     * @param float $workerPingTimeout Seconds without activity before the watcher considers a worker dead
+     *      and terminates it. Default {@see self::DEFAULT_WORKER_PING_TIMEOUT}. Increase or applications that
+     *      legitimately do synchronous blocking work (e.g. PDO drivers) longer than the default ceiling.
      */
-    public function start(int $count, ?float $workerShutdownTimeout = ClusterWatcher::WORKER_TIMEOUT): void
-    {
+    public function start(
+        int $count,
+        ?float $workerShutdownTimeout = self::DEFAULT_WORKER_SHUTDOWN_TIMEOUT,
+        float $workerPingTimeout = self::DEFAULT_WORKER_PING_TIMEOUT,
+    ): void {
         if ($this->running || $this->queue->isComplete()) {
             throw new \Error("The cluster watcher is already running or has already run");
         }
 
         if ($count <= 0) {
-            throw new \Error("The number of workers must be greater than zero");
+            throw new \ValueError("The number of workers must be greater than zero");
+        }
+
+        if ($workerShutdownTimeout <= 0) {
+            throw new \ValueError(
+                'Worker shutdown timeout must be greater than zero (seconds); got ' . $workerShutdownTimeout,
+            );
+        }
+
+        if ($workerPingTimeout <= 0) {
+            throw new \ValueError(
+                'Worker ping timeout must be greater than zero (seconds); got ' . $workerPingTimeout,
+            );
         }
 
         $this->workers = [];
@@ -154,7 +172,7 @@ final class ClusterWatcher
         try {
             for ($i = 0; $i < $count; ++$i) {
                 $id = $this->nextId++;
-                $this->workers[$id] = $this->startWorker($id, $workerShutdownTimeout);
+                $this->workers[$id] = $this->startWorker($id, $workerShutdownTimeout, $workerPingTimeout);
             }
         } catch (\Throwable $exception) {
             $this->stop();
@@ -167,7 +185,7 @@ final class ClusterWatcher
      * @param float|null $shutdownTimeout The maximum time to wait for the worker to shut down, in seconds,
      *  or null to wait indefinitely.
      */
-    private function startWorker(int $id, ?float $shutdownTimeout): ContextClusterWorker
+    private function startWorker(int $id, ?float $shutdownTimeout, float $pingTimeout): ContextClusterWorker
     {
         $context = $this->contextFactory->start($this->script);
 
@@ -206,7 +224,6 @@ final class ClusterWatcher
             $this->queue,
             $deferredCancellation,
             $this->logger,
-            $this->workerPingTimeout,
         );
 
         $worker->info(\sprintf('Started cluster worker with ID %d', $id));
@@ -224,12 +241,13 @@ final class ClusterWatcher
             $deferredCancellation,
             $id,
             $shutdownTimeout,
+            $pingTimeout,
         ): void {
             async($this->provider->provideFor(...), $socket, $deferredCancellation->getCancellation())->ignore();
 
             try {
                 try {
-                    $worker->run($shutdownTimeout);
+                    $worker->run($shutdownTimeout, $pingTimeout);
 
                     $worker->info("Worker {$id} terminated cleanly" .
                         ($this->running ? ", restarting..." : ""));
@@ -251,7 +269,7 @@ final class ClusterWatcher
                 }
 
                 if ($this->running) {
-                    $this->workers[$id] = $this->startWorker($this->nextId++, $shutdownTimeout);
+                    $this->workers[$id] = $this->startWorker($this->nextId++, $shutdownTimeout, $pingTimeout);
                 }
             } catch (\Throwable $exception) {
                 $this->stop();

--- a/src/Internal/ContextClusterWorker.php
+++ b/src/Internal/ContextClusterWorker.php
@@ -37,7 +37,7 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
     use ForbidCloning;
     use ForbidSerialization;
 
-    private const PING_TIMEOUT = 10;
+    public const DEFAULT_PING_TIMEOUT = 10;
 
     private int $lastActivity;
 
@@ -47,6 +47,9 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
      * @param positive-int $id
      * @param Context<mixed, WorkerMessage|null, WatcherMessage|null> $context
      * @param Queue<ClusterWorkerMessage<TReceive, TSend>> $queue
+     * @param positive-int $pingTimeout Seconds without activity before the
+     *     watcher considers the worker dead and terminates it. Must be
+     *     positive; the timer fires every $pingTimeout / 2 seconds.
      */
     public function __construct(
         private readonly int $id,
@@ -55,6 +58,7 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
         private readonly Queue $queue,
         private readonly DeferredCancellation $deferredCancellation,
         private readonly Logger $logger,
+        private readonly int $pingTimeout = self::DEFAULT_PING_TIMEOUT,
     ) {
         $this->lastActivity = \time();
         $this->joinFuture = async($this->context->join(...));
@@ -72,8 +76,8 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
 
     public function run(): void
     {
-        $watcher = EventLoop::repeat(self::PING_TIMEOUT / 2, weakClosure(function (): void {
-            if ($this->lastActivity < \time() - self::PING_TIMEOUT) {
+        $watcher = EventLoop::repeat($this->pingTimeout / 2, weakClosure(function (): void {
+            if ($this->lastActivity < \time() - $this->pingTimeout) {
                 $this->close();
                 return;
             }

--- a/src/Internal/ContextClusterWorker.php
+++ b/src/Internal/ContextClusterWorker.php
@@ -21,6 +21,7 @@ use Monolog\Logger;
 use Psr\Log\AbstractLogger;
 use Revolt\EventLoop;
 use function Amp\async;
+use function Amp\now;
 use function Amp\weakClosure;
 
 /**
@@ -36,7 +37,7 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
     use ForbidCloning;
     use ForbidSerialization;
 
-    private int $lastActivity;
+    private float $lastActivity;
 
     private readonly Future $joinFuture;
 
@@ -53,7 +54,7 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
         private readonly DeferredCancellation $deferredCancellation,
         private readonly Logger $logger,
     ) {
-        $this->lastActivity = \time();
+        $this->lastActivity = now();
         $this->joinFuture = async($this->context->join(...));
     }
 
@@ -79,8 +80,8 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
      */
     public function run(?float $shutdownTimeout, float $pingTimeout): void
     {
-        $watcher = EventLoop::repeat($pingTimeout / 2, weakClosure(function () use ($pingTimeout): void {
-            if ($this->lastActivity < \time() - $pingTimeout) {
+        $watcher = EventLoop::repeat(1, weakClosure(function () use ($pingTimeout): void {
+            if ($this->lastActivity < now() - $pingTimeout) {
                 $this->close();
                 return;
             }
@@ -99,7 +100,7 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
             // In that case, join it.
             /** @var WorkerMessage $message */
             while ($message = $this->context->receive($cancellation)) {
-                $this->lastActivity = \time();
+                $this->lastActivity = now();
 
                 /** @psalm-suppress UnhandledMatchCondition False positive. */
                 match ($message->type) {

--- a/src/Internal/ContextClusterWorker.php
+++ b/src/Internal/ContextClusterWorker.php
@@ -36,8 +36,6 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
     use ForbidCloning;
     use ForbidSerialization;
 
-    public const DEFAULT_PING_TIMEOUT = 10;
-
     private int $lastActivity;
 
     private readonly Future $joinFuture;
@@ -46,9 +44,6 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
      * @param positive-int $id
      * @param Context<mixed, WorkerMessage|null, WatcherMessage|null> $context
      * @param Queue<ClusterWorkerMessage<TReceive, TSend>> $queue
-     * @param positive-int $pingTimeout Seconds without activity before the
-     *     watcher considers the worker dead and terminates it. Must be
-     *     positive; the timer fires every $pingTimeout / 2 seconds.
      */
     public function __construct(
         private readonly int $id,
@@ -57,7 +52,6 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
         private readonly Queue $queue,
         private readonly DeferredCancellation $deferredCancellation,
         private readonly Logger $logger,
-        private readonly int $pingTimeout = self::DEFAULT_PING_TIMEOUT,
     ) {
         $this->lastActivity = \time();
         $this->joinFuture = async($this->context->join(...));
@@ -80,11 +74,13 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
      *
      * @param float|null $shutdownTimeout The maximum time to wait for the worker to shut down, in seconds,
      *    or null to wait indefinitely.
+     * @param float $pingTimeout Seconds without activity before the watcher considers a worker dead
+     *    and terminates it.
      */
-    public function run(?float $shutdownTimeout): void
+    public function run(?float $shutdownTimeout, float $pingTimeout): void
     {
-        $watcher = EventLoop::repeat($this->pingTimeout / 2, weakClosure(function (): void {
-            if ($this->lastActivity < \time() - $this->pingTimeout) {
+        $watcher = EventLoop::repeat($pingTimeout / 2, weakClosure(function () use ($pingTimeout): void {
+            if ($this->lastActivity < \time() - $pingTimeout) {
                 $this->close();
                 return;
             }

--- a/src/Internal/ContextClusterWorker.php
+++ b/src/Internal/ContextClusterWorker.php
@@ -77,12 +77,12 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
     /**
      * Run the worker.
      *
-     * @param float|null $shutdownTimeout The maximum time to wait for the worker to shut down, in seconds,
-     *    or null to wait indefinitely.
      * @param float $pingTimeout Seconds without activity before the watcher considers a worker dead
+     *    or null to wait indefinitely.
+     * @param float|null $shutdownTimeout The maximum time to wait for the worker to shut down, in seconds,
      *    and terminates it.
      */
-    public function run(?float $shutdownTimeout, float $pingTimeout): void
+    public function run(float $pingTimeout, ?float $shutdownTimeout): void
     {
         $interval = new Interval(1, weakClosure(function () use ($pingTimeout): void {
             $this->now = now();
@@ -102,6 +102,8 @@ final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
                 $this->close();
             }
         }), reference: false);
+
+        $this->lastActivity = $this->now;
 
         $cancellation = $this->deferredCancellation->getCancellation();
 

--- a/src/Internal/cluster-runner.php
+++ b/src/Internal/cluster-runner.php
@@ -38,7 +38,11 @@ return static function (Channel $channel) use ($argc, $argv): void {
         // Read random IPC hub URI and associated key from process channel.
         ['id' => $id, 'uri' => $uri, 'key' => $key] = $channel->receive();
 
-        $transferSocket = Ipc\connect($uri, $key, new TimeoutCancellation(ClusterWatcher::WORKER_TIMEOUT));
+        $transferSocket = Ipc\connect(
+            $uri,
+            $key,
+            new TimeoutCancellation(ClusterWatcher::DEFAULT_WORKER_SHUTDOWN_TIMEOUT),
+        );
     } catch (\Throwable $exception) {
         throw new \RuntimeException("Could not connect to IPC socket", 0, $exception);
     }


### PR DESCRIPTION
## Problem

`ContextClusterWorker` (the watcher's per-worker bookkeeping object) hard-codes a 10-second ping timeout:

```php
// src/Internal/ContextClusterWorker.php
final class ContextClusterWorker extends AbstractLogger implements ClusterWorker
{
    private const PING_TIMEOUT = 10;
    // ...
    public function run(): void
    {
        \$watcher = EventLoop::repeat(self::PING_TIMEOUT / 2, weakClosure(function (): void {
            if (\$this->lastActivity < \time() - self::PING_TIMEOUT) {
                \$this->close();
                return;
            }
            // ...
        }));
    }
}
```

This works well when worker handlers are non-blocking. In real-world PHP applications, however, parts of the request lifecycle are **synchronous and blocking**:

- PDO drivers (\`pdo_mysql\`, \`pdo_pgsql\`, …) — they block the event loop until the database responds.
- \`file_get_contents()\` against remote URLs.
- Synchronous Redis clients (e.g. Predis without the async loop adapter).
- CPU-bound work (image processing, PDF rendering).

While such code is blocking, the worker process cannot service the ping, so its \`lastActivity\` is not refreshed. Within ~10s the watcher declares the worker dead and closes its context. From the operator's point of view, the symptom is \`Worker N died unexpectedly: The context stopped responding\` even though the worker was making progress on a single (slow but legitimate) request.

This forces applications that have legitimate >10s blocking work to either (a) avoid \`amphp/cluster\` entirely, (b) split that work into async/queued jobs (a substantial refactor), or (c) vendor-patch \`PING_TIMEOUT\`. Option (c) is what real users end up doing.

## Proposed change

Make the ping timeout a configurable parameter on \`ClusterWatcher\`, threaded through to the internal \`ContextClusterWorker\`. Default value stays \`10\` (no behaviour change for existing users).

### Public API

\`\`\`php
\$watcher = new ClusterWatcher(
    script: __DIR__ . '/server.php',
    logger: \$logger,
    workerPingTimeout: 45, // accommodate legitimate long-blocking work
);
\`\`\`

### Internal change

The hard-coded \`private const PING_TIMEOUT\` becomes \`public const DEFAULT_PING_TIMEOUT\` so it remains the single source of truth and is referenceable from \`ClusterWatcher\`'s constructor signature. \`ContextClusterWorker\` accepts an optional \`int \$pingTimeout\` constructor parameter and uses it in \`EventLoop::repeat()\` and the activity comparison.

### Validation

\`workerPingTimeout < 1\` throws \`\ValueError\` from \`ClusterWatcher\`'s constructor.

### Backwards compatibility

- Default value is \`10\`, matching the previous hard-coded constant.
- New parameter is optional; existing call sites continue to work without change.
- The renamed constant (\`PING_TIMEOUT\` → \`DEFAULT_PING_TIMEOUT\`) was \`private\`, so no public API depended on its name.

## Test plan

- Existing tests continue to pass (defaults are unchanged).
- Manual: run a worker that \`sleep(20)\`s with \`workerPingTimeout=10\` (current behaviour: dies after ~10s) and \`workerPingTimeout=30\` (does not die).

I'm happy to add a unit test for the constructor validation if you'd like — wanted to keep the diff minimal for first review.

## Open questions for the maintainer

1. Should the parameter be on \`ClusterWatcher\`'s constructor (proposed), or on a builder/factory? The constructor is consistent with how \`IpcHub\` etc. are passed today.
2. Naming: \`workerPingTimeout\` vs. \`pingTimeout\` vs. \`pingTimeoutSeconds\`. Open to bikeshedding.
3. Should the value be \`int\` (seconds) or \`float\` (sub-second granularity)? \`EventLoop::repeat()\` accepts a float; the rest of the public API uses \`int\` for time values.
4. CLI: \`vendor/bin/cluster\` could grow a \`--worker-ping-timeout=<int>\` flag — happy to do that in a follow-up if you'd take it here.

## Why we are filing this

We run a cluster of ReactPHP HTTP workers that share long-lived state through Doctrine ORM (synchronous PDO). Specific reporting endpoints have a legitimate execution time that exceeds 10s; today the watcher treats them as dead workers and recycles them mid-response. Bumping \`PING_TIMEOUT\` is the smallest correct change. We're happy to iterate on the design if any of the choices above don't fit.