### PR TITLE
Add --format flag to bin/cluster (console|line|json)

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -9,6 +9,7 @@ use Amp\Log\ConsoleFormatter;
 use Amp\Log\StreamHandler;
 use Amp\TimeoutCancellation;
 use League\CLImate\Argument\Manager as CliArgumentManager;
+use Monolog\Formatter\JsonFormatter;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Logger;
 use Psr\Log\LogLevel;
@@ -30,6 +31,8 @@ const HELP = <<<EOT
     -l, --log                Set the minimum log output level (default: debug)
     -f, --file               Log to file path instead of STDOUT (requires amphp/file)
                              Asterisks (*) in path will be replaced with cluster PID
+        --format             Log output format: console, line, or json (default: console
+                             when logging to STDOUT, line when --file is set)
     -n, --name               Cluster process name
     -p, --pid-file           File path to write current PID to
     -t, --shutdown-timeout   Shutdown timeout in seconds
@@ -84,6 +87,10 @@ $args = [
         "prefix" => "f",
         "longPrefix" => "file",
         "description" => "Log file path. Log messages are written to STDOUT if not specified.",
+    ],
+    "format" => [
+        "longPrefix" => "format",
+        "description" => "Log output format: console, line, or json. Defaults to console when logging to STDOUT and line when --file is set.",
     ],
     "workers" => [
         "prefix" => "w",
@@ -178,21 +185,32 @@ if ($arguments->defined("pid-file")) {
 
 $level = $arguments->get("log");
 
-if ($arguments->defined("file", $argv)) {
+$loggingToFile = $arguments->defined("file", $argv);
+
+if ($loggingToFile) {
     if (!interface_exists(File\File::class)) {
         throw new Exception("amphp/file must be installed to log to a file");
     }
 
     $path = str_replace('*', getmypid(), $arguments->get("file"));
-
     $logHandler = new StreamHandler(File\openFile($path, "a"), $level);
-    $formatter = new LineFormatter;
 } else {
     $logHandler = new StreamHandler(ByteStream\getStdout(), $level);
-    $formatter = new ConsoleFormatter;
 }
 
-$formatter->allowInlineLineBreaks(true);
+$format = $arguments->get("format") ?? ($loggingToFile ? "line" : "console");
+
+$formatter = match ($format) {
+    "console" => new ConsoleFormatter,
+    "line" => new LineFormatter,
+    "json" => new JsonFormatter,
+    default => throw new Exception("Invalid --format value '{$format}'. Valid: console, line, json"),
+};
+
+if ($formatter instanceof LineFormatter) {
+    $formatter->allowInlineLineBreaks(true);
+}
+
 $logHandler->setFormatter($formatter);
 
 $logger = new Logger("cluster-" . getmypid());


### PR DESCRIPTION
## Problem

The cluster watcher in `bin/cluster` hard-wires the log formatter based on whether `--file` is used: `ConsoleFormatter` for STDOUT, `LineFormatter` for files. Both are text formats.

Applications shipping logs to a structured-log backend (DigitalOcean App Platform, Datadog, ELK, GCP Cloud Logging, …) need JSON output so context fields (channel, level_name, datetime, custom context like `requestId`) become first-class queryable fields rather than being buried as a stringified suffix in a text line.

Today the only ways to get JSON are: vendor the binary, replace it with a custom watcher entry point, or post-process logs downstream. Each is a maintenance burden for a 10-line conceptual change.

## Proposed change

Add a new `--format <console|line|json>` flag to `bin/cluster`. Default behaviour is preserved:

- No `--format`, no `--file` → `console` (current default).
- No `--format`, `--file` set → `line` (current default).
- `--format json` → `Monolog\Formatter\JsonFormatter` (one JSON object per line, all fields structured).

The format and transport are now independent: `--format json --file path` works, `--format console` to stdout works, etc.

Invalid values throw a clear `Invalid --format value 'X'. Valid: console, line, json` message.

## Backwards compatibility

- All existing invocations behave identically (defaults unchanged).
- Flag is optional with no value when omitted.
- No public PHP API touched — only `bin/cluster`.

## Test plan

Tested locally with `examples/cluster/hello-world.php` for all three formats and an invalid value:

```
$ php bin/cluster -w 1 --format json examples/cluster/hello-world.php
{"message":"Starting cluster PID 24857 with 1 workers","context":{},"level":200,"level_name":"INFO","channel":"cluster-24857","datetime":"2026-05-08T04:51:47.131421+00:00","extra":{}}
{"message":"Started cluster worker with ID 1","context":{"id":1,"pid":24862},"level":200,"level_name":"INFO","channel":"cluster-24857",...}

$ php bin/cluster -w 1 --format console examples/cluster/hello-world.php
[2026-05-08T04:51:49.143142+00:00] cluster-24917.INFO: Starting cluster PID 24917 with 1 workers [] []
...

$ php bin/cluster -w 1 --format yaml examples/cluster/hello-world.php
PHP Fatal error:  Uncaught Exception: Invalid --format value 'yaml'. Valid: console, line, json
```

I can add unit tests if there's a precedent for testing `bin/cluster` itself — I didn't find one in `test/`, so left it as a manual exercise consistent with the existing CLI surface.

## Why we are filing this

We run a multi-worker ReactPHP cluster and ship logs to DigitalOcean's log explorer, which treats text-suffix JSON as opaque text. Bumping `bin/cluster` to support JSON output is the smallest correct change and keeps the binary as a single source of truth instead of every consumer maintaining a custom launcher.